### PR TITLE
Support Ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ before_script:
 script:
   - ruby ./test/aspect_ratio_test.rb
 rvm:
-  - 2.2
-  - 2.3
   - 2.4
+  - 2.5
+  - 2.6

--- a/aspect_ratio.gemspec
+++ b/aspect_ratio.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name        = 'aspect_ratio'
-  s.version     = '1.0.2'
+  s.version     = '1.0.3'
   s.date        = '2016-04-26'
   s.summary     = 'Image aspect ratio calculation utility'
   s.description = 'Image aspect ratio calculation utility'

--- a/lib/aspect_ratio.rb
+++ b/lib/aspect_ratio.rb
@@ -55,22 +55,22 @@ module AspectRatio
       end
     end
 
-    Δx = ((x - xʹ) / 2).to_f.floor
-    Δy = ((y - yʹ) / 2).to_f.floor
+    delta_x = ((x - xʹ) / 2).to_f.floor
+    delta_y = ((y - yʹ) / 2).to_f.floor
 
     if (vertical || rotate) && !(vertical && rotate)
       [
-        Δy,         # crop top left x
-        Δx,         # crop top left y
-        y - Δy * 2, # crop width
-        x - Δx * 2  # crop height
+        delta_y,         # crop top left x
+        delta_x,         # crop top left y
+        y - delta_y * 2, # crop width
+        x - delta_x * 2  # crop height
       ]
     else
       [
-        Δx.to_f,    # crop top left x
-        Δy,         # crop top left y
-        x - Δx * 2, # crop width
-        y - Δy * 2  # crop height
+        delta_x.to_f,    # crop top left x
+        delta_y,         # crop top left y
+        x - delta_x * 2, # crop width
+        y - delta_y * 2  # crop height
       ]
     end
   end


### PR DESCRIPTION
In Ruby 2.6, we got error:

```
SyntaxError: /Users/viraptor/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/aspect_ratio-1.0.2/lib/aspect_ratio.rb:58: dynamic constant assignment
    Δx = ((x - xʹ) / 2).to_f.floor
```

This PR would address that issue

## TODO:

* Publish this gem to rubygems